### PR TITLE
chore(deps): bump tmp to 0.2.6 to fix CVE-2026-44705

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "less": "^3.0.4",
     "less-loader": "^4.1.0",
     "vue-template-compiler": "^2.6.10"
+  },
+  "resolutions": {
+    "tmp": "0.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,7 +5745,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -7707,12 +7707,10 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@0.2.6, tmp@^0.0.33:
+  version "0.2.6"
+  resolved "https://registry.npmmirror.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR fixes CVE-2026-44705 (High severity) in the `tmp` npm package.

**What changed:**
- Added `resolutions: { "tmp": "0.2.6" }` to `package.json`
- Updated `yarn.lock` with the patched version

**Vulnerability:** Path Traversal via unsanitized prefix/postfix that enables directory escape (CVSS 8.1)
**Fix:** Upgrade to tmp >= 0.2.6

Auto-generated by Hermes Agent.
---
Addresses: [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65)